### PR TITLE
Fix rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,4 @@
 AllCops:
-  TargetRubyVersion: 2.3
-
   Exclude:
     - 'local/**/*'
     - 'vendor/**/*'
@@ -10,20 +8,12 @@ AllCops:
     - 'db/schema.rb'
     - 'locale/translations.rb'
     - 'lib/scratch.rb'
+    - 'schemacop.gemspec'
 
   DisplayCopNames: true
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/SignalException:
   EnforcedStyle: only_fail
-
-Style/ConditionalAssignment:
-  Enabled: false
-
-Style/IndentArray:
-  EnforcedStyle: consistent
 
 Metrics/MethodLength:
   Enabled: false
@@ -51,9 +41,6 @@ Metrics/LineLength:
   Max: 160
 
 Metrics/BlockNesting:
-  Enabled: false
-
-Metrics/BlockLength:
   Enabled: false
 
 Style/IfUnlessModifier:
@@ -92,9 +79,6 @@ Style/ClassAndModuleChildren:
   #   end
   #
   # The compact style is only forced, for classes / modules with one child.
-
-Style/NumericPredicate:
-  Enabled: false
 
 Style/FormatString:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 rvm:
- - 2.0
- - 2.2
  - 2.3.0
 script:
  - bundle install

--- a/lib/schemacop/node_supporting_field.rb
+++ b/lib/schemacop/node_supporting_field.rb
@@ -23,7 +23,7 @@ module Schemacop
       field(*args, required: true, allow_nil: false, &block)
     end
 
-    alias_method req, req!
+    alias_method :req, :req!
 
     def opt?(*args, &block)
       field(*args, required: false, allow_nil: true, &block)
@@ -33,7 +33,7 @@ module Schemacop
       field(*args, required: false, allow_nil: false, &block)
     end
 
-    alias_method opt, opt?
+    alias_method :opt, :opt?
 
     protected
 

--- a/lib/schemacop/node_supporting_field.rb
+++ b/lib/schemacop/node_supporting_field.rb
@@ -23,7 +23,7 @@ module Schemacop
       field(*args, required: true, allow_nil: false, &block)
     end
 
-    alias req req!
+    alias_method req, req!
 
     def opt?(*args, &block)
       field(*args, required: false, allow_nil: true, &block)
@@ -33,7 +33,7 @@ module Schemacop
       field(*args, required: false, allow_nil: false, &block)
     end
 
-    alias opt opt?
+    alias_method opt, opt?
 
     protected
 
@@ -42,7 +42,6 @@ module Schemacop
       # options = args.last.is_a?(Hash) ? args.pop : {}
       name = args.shift
 
-      # rubocop: disable Style/IfInsideElse
       if @fields[name]
         @fields[name].type(*args, &block)
       else
@@ -54,7 +53,6 @@ module Schemacop
           @fields[name] = FieldNode.new(name, required, &block)
         end
       end
-      # rubocop: enable Style/IfInsideElse
 
       @fields[name].type(:nil) if allow_nil
     end


### PR DESCRIPTION
The continuous integration tool shows failures because of the rubocop
linter. This commit should fix all those issues.

Merging of this PR should resolve #4.