### PR TITLE
Graceful validation of hashes with indifferent access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,19 @@
 ### Changes
 -->
 
+## master (unreleased)
+
+### Changes
+
+* Handle `ActiveSupport::HashWithIndifferentAccess` objects gracefully when
+  performing the validation. This allows the user to specify the schema using
+  a mixture of symbols and strings, but during the validation of a
+  `HashWithIndifferentAccess` it transparently converts the keys, both in the
+  schema and in the hash, to symbols.
+
+  In the event that a key is defined both in the string and symbol version,
+  Schemacop expects a Ruby hash and will throw a ValidationError otherwise.
+
 ## 2.1.0 (2017-05-16)
 
 ### New features

--- a/README.md
+++ b/README.md
@@ -226,8 +226,8 @@ option `min` is supported by the `:string` validator (covered later).
 
 ### Field Line
 
-Inside a Type Line of type `:hash` or `Hash`, you may specify an arbitrary
-number of field lines (one for each key-value pair you want to be in the hash).
+Inside a Type Line of type `:hash`, you may specify an arbitrary number of field
+lines (one for each key-value pair you want to be in the hash).
 
 Field Lines start with one of the following six identifiers: `req`, `req?`,
 `req!`, `opt`, `opt?` or `opt!`:
@@ -273,6 +273,36 @@ end
 You might find the notation cumbersome, and you'd be right to say so. Luckily
 there are plenty of short forms available which we will see below.
 
+#### Handling hashes with indifferent access
+
+Schemacop has special handling for objects of the class
+`ActiveSupport::HashWithIndifferentAccess`: You may specify the keys as symbols
+or strings, and Schemacop will handle the conversion necessary for proper
+validation internally. Note that if you define the same key as string and
+symbol, it will throw a `ValidationError` [exception](#exceptions) when asked to
+validate a hash with indifferent access.
+
+Thus, the following two schema definitions are equivalent when validating a hash
+with indifferent access:
+
+```ruby
+Schema.new do
+  type :hash do
+    req :name do
+      type :string
+    end
+  end
+end
+
+Schema.new do
+  type :hash do
+    req 'name' do
+      type :string
+    end
+  end
+end
+```
+
 ## Types
 
 Types are defined via their validators, which is a class under `validator/`.
@@ -317,7 +347,7 @@ The following types are supported by Schemacop by default:
   - TODO no lookahead for different arrays, see
     validator_array_test#test_multiple_arrays
 
-* `:hash` accepts a Ruby Hash.
+* `:hash` accepts a Ruby Hash or an `ActiveSupport::HashWithIndifferentAccess`.
 
   - accepts a block with an arbitrary number of Field Lines.
 

--- a/Rakefile
+++ b/Rakefile
@@ -18,11 +18,15 @@ task :gemspec do
     spec.add_development_dependency 'rake'
     spec.add_development_dependency 'ci_reporter', '~> 2.0'
     spec.add_development_dependency 'ci_reporter_minitest'
-    spec.add_development_dependency 'activesupport'
     spec.add_development_dependency 'haml'
     spec.add_development_dependency 'yard'
     spec.add_development_dependency 'rubocop', '0.35.1'
     spec.add_development_dependency 'redcarpet'
+
+    # This lower bound for ActiveSupport is not necessarily true. Schemacop
+    # needs access to ActiveSupport::HashWithIndifferentAccess and expects
+    # behavior of that as in version 5 of ActiveSupport.
+    spec.add_dependency 'activesupport', '>= 4.0', '< 6'
   end
 
   File.open('schemacop.gemspec', 'w') { |f| f.write(gemspec.to_ruby.strip) }

--- a/lib/schemacop.rb
+++ b/lib/schemacop.rb
@@ -3,6 +3,7 @@ end
 
 require 'set'
 require 'active_support/core_ext/class/attribute'
+require 'active_support/hash_with_indifferent_access'
 
 require 'schemacop/scoped_env'
 require 'schemacop/exceptions'

--- a/lib/schemacop/validator/hash_validator.rb
+++ b/lib/schemacop/validator/hash_validator.rb
@@ -5,8 +5,21 @@ module Schemacop
     def validate(data, collector)
       super
 
-      allowed_fields = @fields.keys
-      obsolete_keys = data.keys - allowed_fields
+      if data.is_a? ActiveSupport::HashWithIndifferentAccess
+        allowed_fields = @fields.keys.map { |k| k.is_a?(String) ? k.to_sym : k }
+        data_keys = data.keys.map { |k| k.is_a?(String) ? k.to_sym : k }
+
+        # If the same key is specified in the schema as string and symbol, we
+        # definitely expect a Ruby hash and not one with indifferent access
+        if @fields.keys.length != Set.new(allowed_fields).length
+          fail Exceptions::ValidationError, 'Hash expected, but got ActiveSupport::HashWithIndifferentAccess.'
+        end
+      else
+        allowed_fields = @fields.keys
+        data_keys = data.keys
+      end
+
+      obsolete_keys = data_keys - allowed_fields
 
       collector.error "Obsolete keys: #{obsolete_keys.inspect}." if obsolete_keys.any?
 


### PR DESCRIPTION
Instead of requiring the schema specification to contain strings when
validating hashes with indifferent access, make it so that string and
symbol key definitions are equivalent.