### PR TITLE
Case-insensitive boolean cast_str

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 3.0.19 (UNRELEASED)
+
+* Make `cast_str` of `BooleanNode` in  `v3` case-insensitive
+
 ## 3.0.18 (2022-07-27)
 
 * Add option `ignore_obsolete_properties` to `HashNode` for Schemacop v3

--- a/README_V3.md
+++ b/README_V3.md
@@ -235,7 +235,9 @@ transformed into various types.
 
 * `boolean`
   The string must be either `true`, `false`, `0` or `1`. This value will be
-  casted to Ruby's `TrueClass` or `FalseClass`.
+  casted to Ruby's `TrueClass` or `FalseClass`. Please note that the strings
+  `true` and `false` are case-insensitive, i.e. `True`, `TRUE` etc. will also
+  work.
 
 * `binary`
   The string is expected to contain binary contents. No casting or additional
@@ -529,7 +531,7 @@ The boolean type is used to validate Ruby booleans, i.e. the `TrueClass` and `Fa
 * `cast_str`
   When set to `true`, this node also accepts strings that can be casted to a
   boolean, namely the values `'true'`, `'false'`, `'1'` and `'0'`. Blank strings
-  will be treated equally as `nil`.
+  will be treated equally as `nil`. This casting is case-insensitive.
 
 #### Examples
 

--- a/lib/schemacop.rb
+++ b/lib/schemacop.rb
@@ -56,8 +56,8 @@ module Schemacop
 
   register_string_formatter(
     :boolean,
-    pattern: /^(true|false|0|1)$/,
-    handler: ->(value) { %w[true 1].include?(value) }
+    pattern: /^(true|false|0|1)$/i,
+    handler: ->(value) { %w[true 1].include?(value&.downcase) }
   )
 
   register_string_formatter(

--- a/test/unit/schemacop/v3/boolean_node_test.rb
+++ b/test/unit/schemacop/v3/boolean_node_test.rb
@@ -184,6 +184,9 @@ module Schemacop
         assert_cast(true, true)
         assert_cast(false, false)
 
+        assert_cast('True', true)
+        assert_cast('False', false)
+
         assert_validation('5') do
           error '/', 'Matches 0 definitions but should match exactly 1.'
         end
@@ -205,6 +208,9 @@ module Schemacop
 
         assert_cast(true, true)
         assert_cast(false, false)
+
+        assert_cast('True', true)
+        assert_cast('False', false)
 
         assert_validation('4') do
           error '/', 'Matches 0 definitions but should match exactly 1.'

--- a/test/unit/schemacop/v3/boolean_node_test.rb
+++ b/test/unit/schemacop/v3/boolean_node_test.rb
@@ -209,8 +209,12 @@ module Schemacop
         assert_cast(true, true)
         assert_cast(false, false)
 
+        # Test case-insentiveness
         assert_cast('True', true)
         assert_cast('False', false)
+
+        assert_cast('TRUE', true)
+        assert_cast('FALSE', false)
 
         assert_validation('4') do
           error '/', 'Matches 0 definitions but should match exactly 1.'


### PR DESCRIPTION
This PR makes the `cast_str` option of the boolean node ignore the case of passed in `true` or `false` string values.