### PR TITLE
Add `require_key` option to node

### DIFF
--- a/README_V3.md
+++ b/README_V3.md
@@ -109,6 +109,16 @@ The nodes in Schemacop v3 also support generic keywords, similar to JSON schema:
   value is not in the array, the validation will fail
 * `default`: You may provide a default value for items that will be set if the
   value is not given
+* `require_key`: If set to true, validate that the key of this node is present, 
+  regardless of the value (including `nil`). This is only validated if the 
+  schema type is set to `:hash`.
+  Example:
+  ```ruby
+  Schemacop::Schema3.new(:hash) do
+    str? :foo, require_key: true
+    int? :bar, require_key: true
+  end
+  ```
 
 The three keywords `title`, `description` and `examples` aren't used for validation,
 but can be used to document the schema. They will be included in the JSON output

--- a/lib/schemacop/v3/hash_node.rb
+++ b/lib/schemacop/v3/hash_node.rb
@@ -109,6 +109,7 @@ module Schemacop
           result.in_path(node.name) do
             next if node.name.is_a?(Regexp)
 
+            result.error "Key #{node.name} must be given." if node.require_key? && !data_hash.include?(node.name)
             node._validate(data_hash[node.name], result: result)
           end
         end

--- a/lib/schemacop/v3/node.rb
+++ b/lib/schemacop/v3/node.rb
@@ -8,6 +8,7 @@ module Schemacop
       attr_reader :description
       attr_reader :options
       attr_reader :parent
+      attr_reader :require_key
 
       class_attribute :_supports_children
       self._supports_children = nil
@@ -50,7 +51,7 @@ module Schemacop
       end
 
       def self.allowed_options
-        %i[name required default description examples enum parent options title as]
+        %i[name required default description examples enum parent options title as require_key]
       end
 
       def self.dsl_methods
@@ -87,6 +88,7 @@ module Schemacop
         @description = options.delete(:description)
         @examples = options.delete(:examples)
         @enum = options.delete(:enum)&.to_set
+        @require_key = !!options.delete(:require_key)
         @parent = options.delete(:parent)
         @options = options
         @schemas = {}
@@ -136,6 +138,10 @@ module Schemacop
         @required
       end
 
+      def require_key?
+        @require_key
+      end
+
       def as_json
         process_json([], {})
       end
@@ -181,6 +187,7 @@ module Schemacop
         json[:description] = @description if @description
         json[:default] = @default unless @default.nil?
         json[:enum] = @enum.to_a if @enum
+        json[:require_key] = @require_key if @require_key
 
         return json.as_json
       end

--- a/test/unit/schemacop/v3/hash_node_test.rb
+++ b/test/unit/schemacop/v3/hash_node_test.rb
@@ -1208,6 +1208,33 @@ module Schemacop
           error '/', 'Obsolete property "obsolete_key".'
         end
       end
+
+      def test_schema_required_key
+        @schema = Schemacop::Schema3.new(:hash) do
+          str? :foo, require_key: true
+          str? :ok, require_key: true
+          int? :bar, require_key: true
+        end
+
+        assert_validation({ ok: nil }) do
+          error '/foo', <<~PLAIN.strip
+            Key foo must be given.
+          PLAIN
+          error '/bar', <<~PLAIN.strip
+            Key bar must be given.
+          PLAIN
+        end
+
+        assert_json({
+                      properties: {
+                        foo: { type: :string, require_key: true },
+                        ok: { type: :string, require_key: true },
+                        bar: { type: :integer, require_key: true }
+                      },
+                      additionalProperties: false,
+                      type: :object
+                    })
+      end
     end
   end
 end

--- a/test/unit/schemacop/v3/hash_node_test.rb
+++ b/test/unit/schemacop/v3/hash_node_test.rb
@@ -1226,13 +1226,13 @@ module Schemacop
         end
 
         assert_json({
-                      properties: {
+                      properties:           {
                         foo: { type: :string, require_key: true },
-                        ok: { type: :string, require_key: true },
+                        ok:  { type: :string, require_key: true },
                         bar: { type: :integer, require_key: true }
                       },
                       additionalProperties: false,
-                      type: :object
+                      type:                 :object
                     })
       end
     end


### PR DESCRIPTION
This change adds the `require_key` option to all nodes which, if set to true, makes sure that the key/name of this node is passed to the hash node validation, even if the value should be `nil`.